### PR TITLE
Only retrieve analysis of workflow + check-wf-swid type

### DIFF
--- a/decider-bcl2fastq/CHANGELOG.md
+++ b/decider-bcl2fastq/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.4 - 2018-12-04
+- [GP-1883](https://jira.oicr.on.ca/browse/GP-1883) - Only retrieve analysis records from "check-wf-accessions"
 ## 1.2.3 - 2018-11-20
 - [GP-1121](https://jira.oicr.on.ca/browse/GP-1121) - Filter 10X lanes
 - [GP-1865](https://jira.oicr.on.ca/browse/GP-1865) - "--no-lane-splitting" mode

--- a/decider-bcl2fastq/pom.xml
+++ b/decider-bcl2fastq/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ca.on.oicr.pde.deciders</groupId>
     <artifactId>BCL2FastQ</artifactId>
-    <version>1.2.4-SNAPSHOT</version>
+    <version>1.2.4</version>
     <packaging>jar</packaging>
 
     <name>${display-name}</name>

--- a/decider-bcl2fastq/pom.xml
+++ b/decider-bcl2fastq/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ca.on.oicr.pde.deciders</groupId>
     <artifactId>BCL2FastQ</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${display-name}</name>

--- a/decider-bcl2fastq/src/main/java/ca/on/oicr/pde/deciders/Bcl2fastqDecider.java
+++ b/decider-bcl2fastq/src/main/java/ca/on/oicr/pde/deciders/Bcl2fastqDecider.java
@@ -567,12 +567,12 @@ public class Bcl2fastqDecider {
 
         //get previous analysis
         Map<FileProvenanceFilter, Set<String>> analysisFilters = new HashMap<>();
+        Set<String> workflowSwidsToCheck = new HashSet<>();
         //TODO: seqware currently does not support retrieving FP with null workflow swids
-        //Set<String> workflowSwidsToCheck = new HashSet<>();
-        //workflowSwidsToCheck.add(getWorkflowAccession());
         //workflowSwidsToCheck.add(null);
-        //workflowSwidsToCheck.addAll(getWorkflowAccessionsToCheck());
-        //analysisFilters.put(FileProvenanceFilter.workflow, workflowSwidsToCheck);
+        workflowSwidsToCheck.add(workflow.getSwAccession().toString());
+        workflowSwidsToCheck.addAll(getWorkflowAccessionsToCheck());
+        analysisFilters.put(FileProvenanceFilter.workflow, workflowSwidsToCheck);
 
         //the set of all lanes that have been analyzed using the current workflow or a workflow in the set of "check workflows"
         Set<String> analyzedLanes = new HashSet<>();

--- a/decider-bcl2fastq/src/test/java/ca/on/oicr/pde/deciders/Bcl2fastqDeciderTest.java
+++ b/decider-bcl2fastq/src/test/java/ca/on/oicr/pde/deciders/Bcl2fastqDeciderTest.java
@@ -453,13 +453,16 @@ public class Bcl2fastqDeciderTest {
         assertEquals(bcl2fastqDecider.getValidWorkflowRuns().size(), 1);
         assertEquals(bcl2fastqDecider.getInvalidLanes().size(), 0);
 
-        bcl2fastqDecider.setIsDryRunMode(false);
-        bcl2fastqDecider.setDoCreateIusLimsKeys(true);
-        bcl2fastqDecider.setDoScheduleWorkflowRuns(true);
-        assertEquals(bcl2fastqDecider.run().size(), 0);
-        assertEquals(bcl2fastqDecider.getScheduledWorkflowRuns().size(), 0);
-        assertEquals(bcl2fastqDecider.getValidWorkflowRuns().size(), 0);
-        assertEquals(bcl2fastqDecider.getInvalidLanes().size(), 0);
+        // The above bcl2fastqDecider only creates iusLimsKeys and does not schedule a workflow run.
+        // The bcl2fastq decider has been updated to only retieve analysis of type "current workflow swid" and "check-wf-swid".
+        // This results in the below case not being blocked.  This case can be re-enabled when analysis provenance filtering supports null.
+        //bcl2fastqDecider.setIsDryRunMode(false);
+        //bcl2fastqDecider.setDoCreateIusLimsKeys(true);
+        //bcl2fastqDecider.setDoScheduleWorkflowRuns(true);
+        //assertEquals(bcl2fastqDecider.run().size(), 0);
+        //assertEquals(bcl2fastqDecider.getScheduledWorkflowRuns().size(), 0);
+        //assertEquals(bcl2fastqDecider.getValidWorkflowRuns().size(), 0);
+        //assertEquals(bcl2fastqDecider.getInvalidLanes().size(), 0);
 
         bcl2fastqDecider.setIsDryRunMode(false);
         bcl2fastqDecider.setDoCreateIusLimsKeys(true);


### PR DESCRIPTION
- This is to reduce request size but has a downside that IUS-LimsKeys are no longer retrieved (as this analysis type has no workflow swid)