### PR TITLE
Fix signal bug

### DIFF
--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -796,14 +796,13 @@ int main(int argc, char **argv) {
   stats_data >> stats_json;
 
   std::set<int> reads;
-  for (Json::ArrayIndex i = 0; i < stats_json["ConversionResults"].size();
+  for (Json::ArrayIndex i = 0; i < stats_json["ReadInfosForLanes"].size();
        i++) {
-    auto &cr = stats_json["ConversionResults"][i];
-    for (Json::ArrayIndex j = 0; j < cr["Undetermined"]["ReadMetrics"].size();
-         j++) {
-      auto &rm = cr["Undetermined"]["ReadMetrics"][j];
-      for (Json::ArrayIndex k = 0; k < rm.size(); k++) {
-        reads.insert(rm["ReadNumber"].asInt());
+    auto &ril = stats_json["ReadInfosForLanes"][i];
+    for (Json::ArrayIndex j = 0; j < ril["ReadInfos"].size(); j++) {
+      auto &ri = ril["ReadInfos"][j];
+      for (Json::ArrayIndex k = 0; k < ri.size(); k++) {
+        reads.insert(ri["Number"].asInt());
       }
     }
   }

--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -509,7 +509,6 @@ static void conditional_rewrite(pid_t child, int filename_register,
     // the search string we've seen
     for (auto i = 0; i < sizeof(long); i++) {
       if (value.c[i] == '\0') {
-        std::cerr << "Meh. It's some other file." << std::endl;
         return;
       }
       if (value.c[i] == *current_search_filename) {
@@ -573,12 +572,10 @@ static bool run_process(pid_t child) {
         static_assert(
             sizeof(devnull) % sizeof(long) == 0,
             "undetermined replacement path is not a multiple of long");
-        std::cerr << "Investigating open() system call" << std::endl;
         conditional_rewrite(child, RDI, "Undetermined", devnull,
                             sizeof(devnull));
         break;
       case 257: // openat()
-        std::cerr << "Investigating openat() system call" << std::endl;
         conditional_rewrite(child, RSI, "Undetermined", devnull,
                             sizeof(devnull));
         break;
@@ -592,7 +589,6 @@ static bool run_process(pid_t child) {
       case 6: // lstat()
         static_assert(sizeof(binls) % sizeof(long) == 0,
                       "stat replacement path is not a multiple of long");
-        std::cerr << "Investigating stat()/lstat() system call" << std::endl;
         conditional_rewrite(child, RDI, "/dev/null", binls, sizeof(binls));
         break;
       }


### PR DESCRIPTION
This tries to fix a bug where if `bcl2fastq` segfaulted, then `bcl2fastq-jail` would enter an infinite loop writing lots of error messages to the log.

* Write fewer debugging messages
* Fix child signal handling  
  When a child recieves a signal, the parent has the option to hide the signal.
  This passes the signal number to the child process using `ptrace` so that the
  child will handle it (if it can). This should avoid an infinite loop in the
  caller when the child hits a segmentation fault.